### PR TITLE
created previewBorderRadius prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -737,10 +737,9 @@ class AvatarImageCropper extends React.Component {
                 onTouchStart={this._onMouseDown}
                 style={{
                   ...this.previewStyle,
-              
                   backgroundImage: 'url(' + this.state.preview + ')',
                   backgroundSize: sizeW + 'px ' + sizeH + 'px',
-                  backgroundPosition: '' + relX + 'px ' + relY + 'px',
+                  backgroundPosition: '' + relX + 'px ' + relY + 'px'
                 }}
               />
             </div>

--- a/src/index.js
+++ b/src/index.js
@@ -139,6 +139,10 @@ class AvatarImageCropper extends React.Component {
      */
     className: PropTypes.string,
     /**
+     * Border Radius to apply to the preview.
+     */
+    previewBorderRadius: PropTypes.string,
+    /**
      * Override the inline-styles of the initial icon style.
      */
     iconStyle: PropTypes.object,
@@ -254,18 +258,18 @@ class AvatarImageCropper extends React.Component {
     width: '100%',
     cursor: 'pointer'
   }
-
   previewStyle = {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     bottom: 0,
     right: 0,
     left: 0,
     zIndex: 9,
-    backgroundRepeat: 'no-repeat',
-    cursor: 'move',
-    backgroundPosition: '0% 0%'
-  }
+    backgroundRepeat: "no-repeat",
+    cursor: "move",
+    backgroundPosition: "0% 0%",
+    borderRadius: this.props.previewBorderRadius,
+  };
 
   cropStyle = {
     height: '100%',
@@ -732,9 +736,10 @@ class AvatarImageCropper extends React.Component {
                 onTouchStart={this._onMouseDown}
                 style={{
                   ...this.previewStyle,
+              
                   backgroundImage: 'url(' + this.state.preview + ')',
                   backgroundSize: sizeW + 'px ' + sizeH + 'px',
-                  backgroundPosition: '' + relX + 'px ' + relY + 'px'
+                  backgroundPosition: '' + relX + 'px ' + relY + 'px',
                 }}
               />
             </div>
@@ -818,6 +823,7 @@ class AvatarImageCropper extends React.Component {
  */
 
 /* global self */
+
 /* jslint bitwise: true, regexp: true, confusion: true, es5: true, vars: true, white: true,
   plusplus: true */
 

--- a/src/index.js
+++ b/src/index.js
@@ -284,6 +284,7 @@ class AvatarImageCropper extends React.Component {
     height: '100%',
     display: 'block',
     position: 'relative',
+    borderRadius: this.props.previewBorderRadius,
     backgroundColor: this.props.isBack ? 'rgba(0,0,0,0.4)' : 'transparent'
   }
 


### PR DESCRIPTION
Hello, i saw that the library doesn't contain a previewBorderRadius prop so i created one so the preview ca be changed which initially was  impossible and it was represented only as a square. The end user will only have to use it like in the following example:   AvatarImageCropper  previewBorderRadius="500px" 
 

